### PR TITLE
bug(render-chat-image): add delay for rendering image

### DIFF
--- a/src/pages/ChatPage/components/Message/index.tsx
+++ b/src/pages/ChatPage/components/Message/index.tsx
@@ -41,34 +41,32 @@ interface IMessageContentProps {
 }
 
 const MessageContent = ({ messagePhotoUrl, message, createdAt }: IMessageContentProps) => {
-  const [src, setSrc] = useState(messagePhotoUrl);
+  const [src, setSrc] = useState<string | null>(null);
 
   useEffect(() => {
     if (!messagePhotoUrl) return;
-    setSrc(`${S3_URL}/${S3_CHAT_PHOTO_ENVIRONMENT}/${messagePhotoUrl}`);
+
+    const url = `${S3_URL}/${S3_CHAT_PHOTO_ENVIRONMENT}/${encodeURI(messagePhotoUrl)}`;
+    const timeout = setTimeout(() => setSrc(url), 1000);
+
+    return () => clearTimeout(timeout);
   }, [messagePhotoUrl]);
 
-  if (src) {
-    return (
-      <div className={messageStyles}>
+  return (
+    <div className={messageStyles}>
+      {src ? (
         <img
           className="cursor-pointer"
           src={src}
           alt="message"
           width={100}
-          onClick={() => {
-            window.open(src, '_blank');
-          }}
+          onClick={() => window.open(src, '_blank')}
+          referrerPolicy="no-referrer"
         />
-        <RecordCreatedAt className="text-right" createdAt={createdAt} />
-      </div>
-    );
-  }
-
-  return (
-    <div className={messageStyles}>
-      <p>{message}</p>
-      <RecordCreatedAt createdAt={createdAt} />
+      ) : (
+        <p>{message}</p>
+      )}
+      <RecordCreatedAt className="text-right" createdAt={createdAt} />
     </div>
   );
 };

--- a/src/pages/ChatPage/components/Message/index.tsx
+++ b/src/pages/ChatPage/components/Message/index.tsx
@@ -46,7 +46,7 @@ const MessageContent = ({ messagePhotoUrl, message, createdAt }: IMessageContent
   useEffect(() => {
     if (!messagePhotoUrl) return;
 
-    const url = `${S3_URL}/${S3_CHAT_PHOTO_ENVIRONMENT}/${encodeURI(messagePhotoUrl)}`;
+    const url = `${S3_URL}/${S3_CHAT_PHOTO_ENVIRONMENT}/${encodeURIComponent(messagePhotoUrl)}`;
     const timeout = setTimeout(() => setSrc(url), 1000);
 
     return () => clearTimeout(timeout);


### PR DESCRIPTION
- rerender chat image when uploaded to s3
- Here is how the flow works BE and FE

##### On Be
1. Sharp starts processing the image (resize, convert, etc.)
2. multer-s3 creates one or more transformed versions and uploads them to S3.
3.  S3 accepts the upload, but...
4. S3 may take a moment to propagate that object to its public edge network (especially if your bucket uses versioning, encryption, or CloudFront).
##### On FE
5. During this delay, the object technically exists, but S3 may still respond with 403 or 404 until it's fully "ready".


https://github.com/user-attachments/assets/529e775f-49c5-4c64-b576-4ee704ccf377

