### PR TITLE
fix(esbuild-fix): add rebuild to build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc -b && npm rebuild esbuild && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
     "prepare": "husky"


### PR DESCRIPTION
- add `rebuild esbuild` to build script
- this will fix all failing builds in other branches
- esbuild has some issues on Netlify