### PR TITLE
migrate to absolute imports

### DIFF
--- a/src/api/chatMessages/index.ts
+++ b/src/api/chatMessages/index.ts
@@ -1,6 +1,6 @@
 import { apiClient } from '..';
-import { IMessage } from '../../pages/ChatPage/components/Message';
-import { API_KEY } from '../../utils/consts';
+import { IMessage } from '@app/pages/ChatPage/components/Message';
+import { API_KEY } from '@app/utils/consts';
 
 export const getChatMessages = async (chatId: string, page: number) => {
   const client = apiClient();

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { getErrorMessage } from '../utils/getErrorMessage';
+import { getErrorMessage } from '@app/utils/getErrorMessage';
 
 const getCookie = (name: string) => {
   const cookies = document.cookie.split('; ');

--- a/src/components/AppLayout/index.tsx
+++ b/src/components/AppLayout/index.tsx
@@ -1,7 +1,7 @@
 import { SyntheticEvent } from 'react';
-import AppContainer from '../AppContainer';
-import Footer from '../Footer';
-import Navigation from '../Navigation';
+import AppContainer from '@app/components/AppContainer';
+import Footer from '@app/components/Footer';
+import Navigation from '@app/components/Navigation';
 
 interface IAppLayoutProps {
   children: React.ReactNode;

--- a/src/components/AuthLogo/index.tsx
+++ b/src/components/AuthLogo/index.tsx
@@ -1,4 +1,4 @@
-import svg from '../../assets/auth.svg';
+import svg from '@app/assets/auth.svg';
 
 const AuthLogo = () => {
   return <img src={svg} />;

--- a/src/components/ConfirmModal/index.tsx
+++ b/src/components/ConfirmModal/index.tsx
@@ -1,5 +1,5 @@
 import Modal from 'react-modal';
-import Button from '../Button';
+import Button from '@app/components/Button';
 
 interface IConfirmModalProps {
   isOpen: boolean;

--- a/src/components/Cta/index.tsx
+++ b/src/components/Cta/index.tsx
@@ -1,4 +1,4 @@
-import Button from '../Button';
+import Button from '@app/components/Button';
 
 interface ICtaProps {
   title: string;

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -1,4 +1,4 @@
-import Divider from '../Divider';
+import Divider from '@app/components/Divider';
 
 const Footer = () => {
   return (

--- a/src/components/GiphySearch/hooks/index.ts
+++ b/src/components/GiphySearch/hooks/index.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { getTrendingGIFS, getSearchGIFS } from '../../../api/chatMessages';
+import { getTrendingGIFS, getSearchGIFS } from '@app/api/chatMessages';
 
 export const useGIFS = (term: string, page: number = 1, limit: number = 8) => {
   const {

--- a/src/components/GiphySearch/index.tsx
+++ b/src/components/GiphySearch/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { debounce } from 'lodash';
-import Input from '../Input';
+import Input from '@app/components/Input';
 import { useGIFS } from './hooks';
 
 interface GiphyResult {

--- a/src/components/LatestComments/hooks/index.ts
+++ b/src/components/LatestComments/hooks/index.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { getLatestUploadComments } from '../../../api/uploadsComments';
+import { getLatestUploadComments } from '@app/api/uploadsComments';
 
 export const useGetLatestComments = () => {
   const {

--- a/src/components/LatestComments/index.tsx
+++ b/src/components/LatestComments/index.tsx
@@ -1,12 +1,12 @@
 import { useNavigate } from 'react-router';
-import { useGetUserById } from '../../hooks/useGetUserById';
-import Card from '../Card';
-import Loader from '../Loader';
-import RecordCreatedAt from '../RecordCreatedAt';
+import { useGetUserById } from '@app/hooks/useGetUserById';
+import Card from '@app/components/Card';
+import Loader from '@app/components/Loader';
+import RecordCreatedAt from '@app/components/RecordCreatedAt';
 import { useGetLatestComments } from './hooks';
 import Avatar from 'react-avatar';
-import { getProfilePhoto, getProfilePhotoUrl } from '../../utils/getProfilePhoto';
-import { useGetAllImages } from '../../hooks/useGetAllImages';
+import { getProfilePhoto, getProfilePhotoUrl } from '@app/utils/getProfilePhoto';
+import { useGetAllImages } from '@app/hooks/useGetAllImages';
 import DOMPurify from 'dompurify';
 
 interface IComment {

--- a/src/components/LatestMessages/index.tsx
+++ b/src/components/LatestMessages/index.tsx
@@ -1,14 +1,14 @@
 import { useLocalStorage } from '@uidotdev/usehooks';
-import { useGetAllUserChats } from '../../hooks/useGetAllUserChats';
-import Card from '../Card';
+import { useGetAllUserChats } from '@app/hooks/useGetAllUserChats';
+import Card from '@app/components/Card';
 import { useNavigate } from 'react-router';
-import RecordCreatedAt from '../RecordCreatedAt';
-import { useGetAllImages } from '../../hooks/useGetAllImages';
+import RecordCreatedAt from '@app/components/RecordCreatedAt';
+import { useGetAllImages } from '@app/hooks/useGetAllImages';
 import Avatar from 'react-avatar';
-import { getProfilePhoto, getProfilePhotoUrl } from '../../utils/getProfilePhoto';
-import { useGetUserById } from '../../hooks/useGetUserById';
-import { S3_URL } from '../../utils/consts';
-import { useGetIsMessageRead, useMarkMessagesAsRead } from '../../pages/NewChatPage/hooks';
+import { getProfilePhoto, getProfilePhotoUrl } from '@app/utils/getProfilePhoto';
+import { useGetUserById } from '@app/hooks/useGetUserById';
+import { S3_URL } from '@app/utils/consts';
+import { useGetIsMessageRead, useMarkMessagesAsRead } from '@app/pages/NewChatPage/hooks';
 
 interface IMessage {
   id: number;

--- a/src/components/LatestUploads/components/LatestUpload/index.tsx
+++ b/src/components/LatestUploads/components/LatestUpload/index.tsx
@@ -1,9 +1,9 @@
 import { useNavigate } from 'react-router';
-import { S3_URL } from '../../../../utils/consts';
-import { useGetUserById } from '../../../../hooks/useGetUserById';
-import { useGetAllImages } from '../../../../hooks/useGetAllImages';
+import { S3_URL } from '@app/utils/consts';
+import { useGetUserById } from '@app/hooks/useGetUserById';
+import { useGetAllImages } from '@app/hooks/useGetAllImages';
 import Avatar from 'react-avatar';
-import { getProfilePhoto, getProfilePhotoUrl } from '../../../../utils/getProfilePhoto';
+import { getProfilePhoto, getProfilePhotoUrl } from '@app/utils/getProfilePhoto';
 
 interface IUpload {
   id: string;

--- a/src/components/LatestUploads/hooks/index.ts
+++ b/src/components/LatestUploads/hooks/index.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { getLatestUploads } from '../../../api/uploads';
+import { getLatestUploads } from '@app/api/uploads';
 
 export const useGetLatestUploads = () => {
   const {

--- a/src/components/LatestUploads/index.tsx
+++ b/src/components/LatestUploads/index.tsx
@@ -1,4 +1,4 @@
-import Card from '../Card';
+import Card from '@app/components/Card';
 import LatestUpload from './components/LatestUpload';
 import { useGetLatestUploads } from './hooks';
 

--- a/src/components/MentionInput/hooks/index.ts
+++ b/src/components/MentionInput/hooks/index.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { getUserByUsername } from '../../../api/users';
+import { getUserByUsername } from '@app/api/users';
 
 export const useGetUserByUsername = (username: string) => {
   const {

--- a/src/components/MentionInput/index.tsx
+++ b/src/components/MentionInput/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
-import { IUser } from '../UserCard';
+import { IUser } from '@app/components/UserCard';
 import { useGetUserByUsername } from './hooks';
-import { debounceScroll } from '../../utils/debounceScroll';
+import { debounceScroll } from '@app/utils/debounceScroll';
 
 interface MentionInputProps {
   value: string;

--- a/src/components/Navigation/components/Notifications/index.tsx
+++ b/src/components/Navigation/components/Notifications/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
-import { useGetAllNotifcations, useMarkAsReadNotification } from '../../hooks';
-import { useSocket } from '../../../../context/useSocket';
+import { useGetAllNotifcations, useMarkAsReadNotification } from '@app/components/Navigation/hooks';
+import { useSocket } from '@app/context/useSocket';
 import { useNavigate } from 'react-router-dom';
 
 export type Notification = {

--- a/src/components/Navigation/components/OnlineStatus/index.tsx
+++ b/src/components/Navigation/components/OnlineStatus/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useSocket } from '../../../../context/useSocket';
+import { useSocket } from '@app/context/useSocket';
 
 const StatusDropdown = ({ userId }: { userId: number | null }) => {
   const socket = useSocket();

--- a/src/components/Navigation/hooks/index.ts
+++ b/src/components/Navigation/hooks/index.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation } from '@tanstack/react-query';
-import { getAllNotifications, markAsReadNotification } from '../../../api/notifications';
+import { getAllNotifications, markAsReadNotification } from '@app/api/notifications';
 
 export const useGetAllNotifcations = (userId: string) => {
   const {

--- a/src/components/Navigation/index.tsx
+++ b/src/components/Navigation/index.tsx
@@ -1,12 +1,12 @@
 import { useLocalStorage } from '@uidotdev/usehooks';
 import { Link } from 'react-router';
 import { BiExit } from 'react-icons/bi';
-import ProfilePhoto from '../ProfilePhoto';
-import { useGetAllImages } from '../../hooks/useGetAllImages';
-import { getProfilePhoto, getProfilePhotoUrl } from '../../utils/getProfilePhoto';
+import ProfilePhoto from '@app/components/ProfilePhoto';
+import { useGetAllImages } from '@app/hooks/useGetAllImages';
+import { getProfilePhoto, getProfilePhotoUrl } from '@app/utils/getProfilePhoto';
 import { useCookies } from 'react-cookie';
-import { useGetUserById } from '../../hooks/useGetUserById';
-import Loader from '../Loader';
+import { useGetUserById } from '@app/hooks/useGetUserById';
+import Loader from '@app/components/Loader';
 import { useAuth0 } from '@auth0/auth0-react';
 import NotificationDropdown from './components/Notifications';
 import OnlineStatus from './components/OnlineStatus';

--- a/src/components/Paginated/index.tsx
+++ b/src/components/Paginated/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import Button from '../Button';
+import Button from '@app/components/Button';
 import { BiChevronLeft, BiChevronRight } from 'react-icons/bi';
 
 interface IPaginatedProps<T> {

--- a/src/components/PhotoComments/components/CommentWithUser.tsx
+++ b/src/components/PhotoComments/components/CommentWithUser.tsx
@@ -1,16 +1,16 @@
 import { useState } from 'react';
 import { IComment } from '..';
-import { useGetUserById } from '../../../hooks/useGetUserById';
-import Button from '../../Button';
-import { useDeleteUploadComment, useEditUploadComment } from '../hooks';
+import { useGetUserById } from '@app/hooks/useGetUserById';
+import Button from '@app/components/Button';
+import { useDeleteUploadComment, useEditUploadComment } from '@app/components/PhotoComments/hooks';
 import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
-import FieldError from '../../FieldError';
+import FieldError from '@app/components/FieldError';
 import { useLocalStorage } from '@uidotdev/usehooks';
-import MentionInput from '../../MentionInput';
+import MentionInput from '@app/components/MentionInput';
 import { Link } from 'react-router-dom';
-import { IUser } from '../../UserCard';
+import { IUser } from '@app/components/UserCard';
 import DOMPurify from 'dompurify';
 
 interface Inputs {

--- a/src/components/PhotoComments/hooks/index.ts
+++ b/src/components/PhotoComments/hooks/index.ts
@@ -4,10 +4,10 @@ import {
   deleteUploadComment,
   editUploadComment,
   getUploadComments,
-} from '../../../api/uploadsComments';
+} from '@app/api/uploadsComments';
 import { toast } from 'react-toastify';
-import { toastConfig } from '../../../configs/toast.config';
-import { useSocket } from '../../../context/useSocket';
+import { toastConfig } from '@app/configs/toast.config';
+import { useSocket } from '@app/context/useSocket';
 interface IAddUploadCommentProps {
   userId: string;
   uploadId: string;

--- a/src/components/PhotoComments/index.tsx
+++ b/src/components/PhotoComments/index.tsx
@@ -1,17 +1,17 @@
 import { Controller, useForm } from 'react-hook-form';
-import Button from '../Button';
+import Button from '@app/components/Button';
 import { useAddUploadComment, useGetUploadComments } from './hooks';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { useLocalStorage } from '@uidotdev/usehooks';
 import { useParams } from 'react-router';
 import CommentWithUser from './components/CommentWithUser';
-import FieldError from '../FieldError';
+import FieldError from '@app/components/FieldError';
 import { useEffect, useState } from 'react';
-import Paginated from '../Paginated';
-import { useSocket } from '../../context/useSocket';
-import MentionInput from '../MentionInput';
-import { IUser } from '../UserCard';
+import Paginated from '@app/components/Paginated';
+import { useSocket } from '@app/context/useSocket';
+import MentionInput from '@app/components/MentionInput';
+import { IUser } from '@app/components/UserCard';
 
 const schema = z.object({
   comment: z

--- a/src/components/PhotoLikes/hooks/index.ts
+++ b/src/components/PhotoLikes/hooks/index.ts
@@ -1,8 +1,8 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { toast } from 'react-toastify';
-import { toastConfig } from '../../../configs/toast.config';
-import { addUploadLike, getUploadLikes, removeUploadLike } from '../../../api/uploadsLikes';
-import { useSocket } from '../../../context/useSocket';
+import { toastConfig } from '@app/configs/toast.config';
+import { addUploadLike, getUploadLikes, removeUploadLike } from '@app/api/uploadsLikes';
+import { useSocket } from '@app/context/useSocket';
 
 export const useUpvoteUpload = () => {
   const socket = useSocket();

--- a/src/components/PhotoLikes/index.tsx
+++ b/src/components/PhotoLikes/index.tsx
@@ -2,7 +2,7 @@ import { useLocalStorage } from '@uidotdev/usehooks';
 import { BiHeart, BiSolidHeart } from 'react-icons/bi';
 import { useDownvoteUpload, useGetUploadUpvotes, useUpvoteUpload } from './hooks';
 import { useEffect, useState } from 'react';
-import { useSocket } from '../../context/useSocket';
+import { useSocket } from '@app/context/useSocket';
 import PhotoLikeDropdown from './components/LikesList';
 
 interface IPhotoLikesProps {

--- a/src/components/PhotoUploader/hooks/index.ts
+++ b/src/components/PhotoUploader/hooks/index.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'react-toastify';
-import { toastConfig } from '../../../configs/toast.config';
-import { uploadPhotos } from '../../../api/uploads';
+import { toastConfig } from '@app/configs/toast.config';
+import { uploadPhotos } from '@app/api/uploads';
 
 export const useUploadPhotos = (id: string) => {
   const queryClient = useQueryClient();

--- a/src/components/PhotoUploader/index.tsx
+++ b/src/components/PhotoUploader/index.tsx
@@ -1,18 +1,18 @@
 import { useLocalStorage } from '@uidotdev/usehooks';
-import { IImage } from '../Photos';
+import { IImage } from '@app/components/Photos';
 import { SyntheticEvent, useEffect, useRef, useState } from 'react';
 import { useUploadPhotos } from './hooks';
-import Button from '../Button';
-import Input from '../Input';
+import Button from '@app/components/Button';
+import Input from '@app/components/Input';
 import { BiTrash } from 'react-icons/bi';
-import { removeSpacesAndDashes } from '../../utils/removeSpacesAndDashes';
-import Card from '../Card';
-import { useGetAllImages } from '../../hooks/useGetAllImages';
-import { useDeletePhoto } from '../Photos/hooks';
+import { removeSpacesAndDashes } from '@app/utils/removeSpacesAndDashes';
+import Card from '@app/components/Card';
+import { useGetAllImages } from '@app/hooks/useGetAllImages';
+import { useDeletePhoto } from '@app/components/Photos/hooks';
 import { toast } from 'react-toastify';
-import { toastConfig } from '../../configs/toast.config';
-import { getImageUrl } from '../../utils/getImageUrl';
-import ConfirmModal from '../ConfirmModal';
+import { toastConfig } from '@app/configs/toast.config';
+import { getImageUrl } from '@app/utils/getImageUrl';
+import ConfirmModal from '@app/components/ConfirmModal';
 export interface ImageDescription {
   description: string;
   imageId: string;

--- a/src/components/Photos/hooks/index.ts
+++ b/src/components/Photos/hooks/index.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { deleteImage } from '../../../api/uploads';
+import { deleteImage } from '@app/api/uploads';
 import { toast } from 'react-toastify';
-import { toastConfig } from '../../../configs/toast.config';
+import { toastConfig } from '@app/configs/toast.config';
 
 interface DeletePhotoParams {
   url: string;

--- a/src/components/Photos/index.tsx
+++ b/src/components/Photos/index.tsx
@@ -1,9 +1,9 @@
 import { SetStateAction } from 'react';
-import notFound from '../../assets/not_found.svg';
-import { ImageDescription } from '../PhotoUploader';
+import notFound from '@app/assets/not_found.svg';
+import { ImageDescription } from '@app/components/PhotoUploader';
 import { useNavigate } from 'react-router';
-import { getImageUrl } from '../../utils/getImageUrl';
-import PhotoLikes from '../PhotoLikes';
+import { getImageUrl } from '@app/utils/getImageUrl';
+import PhotoLikes from '@app/components/PhotoLikes';
 export interface IImage {
   createdAt: string;
   description: string;

--- a/src/components/ProfilePhoto/index.tsx
+++ b/src/components/ProfilePhoto/index.tsx
@@ -1,6 +1,6 @@
 import Avatar from 'react-avatar';
 import { Link } from 'react-router';
-import { IUser } from '../UserCard';
+import { IUser } from '@app/components/UserCard';
 
 interface IProfilePhotoProps {
   url: string;

--- a/src/components/SendMessageButton/index.tsx
+++ b/src/components/SendMessageButton/index.tsx
@@ -1,7 +1,7 @@
 import { useLocalStorage } from '@uidotdev/usehooks';
-import { IChat, useCreateNewChat } from '../../pages/NewChatPage/hooks';
-import Button, { ButtonType } from '../Button';
-import { useGetAllUserChats } from '../../hooks/useGetAllUserChats';
+import { IChat, useCreateNewChat } from '@app/pages/NewChatPage/hooks';
+import Button, { ButtonType } from '@app/components/Button';
+import { useGetAllUserChats } from '@app/hooks/useGetAllUserChats';
 import { useNavigate } from 'react-router';
 import { hasAlreadyChatted } from './utils/hasAlreadyChatted';
 import { useState } from 'react';

--- a/src/components/SendMessageButton/utils/hasAlreadyChatted.ts
+++ b/src/components/SendMessageButton/utils/hasAlreadyChatted.ts
@@ -1,4 +1,4 @@
-import { IChat } from '../../../pages/NewChatPage/hooks';
+import { IChat } from '@app/pages/NewChatPage/hooks';
 
 export const hasAlreadyChatted = (userChats: IChat[], userId: string) => {
   return userChats?.some((chat: IChat) => Number(chat.Users[0].id) === Number(userId));

--- a/src/components/UserCard/index.tsx
+++ b/src/components/UserCard/index.tsx
@@ -1,11 +1,11 @@
-import Button from '../Button';
+import Button from '@app/components/Button';
 import Avatar from 'react-avatar';
-import Card from '../Card';
-import { getUserBio } from '../UserProfileCard/utils';
+import Card from '@app/components/Card';
+import { getUserBio } from '@app/components/UserProfileCard/utils';
 import { BiSolidMap, BiStopwatch } from 'react-icons/bi';
-import { getProfilePhoto, getProfilePhotoUrl } from '../../utils/getProfilePhoto';
-import { useGetAllImages } from '../../hooks/useGetAllImages';
-import { useStatusMap } from '../../context/OnlineStatus/useStatusMap';
+import { getProfilePhoto, getProfilePhotoUrl } from '@app/utils/getProfilePhoto';
+import { useGetAllImages } from '@app/hooks/useGetAllImages';
+import { useStatusMap } from '@app/context/OnlineStatus/useStatusMap';
 import clsx from 'clsx';
 export interface IUser {
   avatar: string;

--- a/src/components/UserFilters/index.tsx
+++ b/src/components/UserFilters/index.tsx
@@ -1,7 +1,7 @@
-import Input from '../Input';
+import Input from '@app/components/Input';
 import { BiSearch } from 'react-icons/bi';
 import Select from 'react-select';
-import { IUser } from '../UserCard';
+import { IUser } from '@app/components/UserCard';
 import { SyntheticEvent } from 'react';
 
 const selectOptions: { value: keyof IUser; label: string }[] = [

--- a/src/components/UserProfileCard/index.tsx
+++ b/src/components/UserProfileCard/index.tsx
@@ -1,5 +1,5 @@
-import Card from '../Card';
-import { getProfilePhoto, getProfilePhotoUrl } from '../../utils/getProfilePhoto';
+import Card from '@app/components/Card';
+import { getProfilePhoto, getProfilePhotoUrl } from '@app/utils/getProfilePhoto';
 import Avatar from 'react-avatar';
 import { BiBody, BiBoltCircle, BiCheckCircle, BiSolidMap, BiStopwatch, BiX } from 'react-icons/bi';
 import {
@@ -10,9 +10,9 @@ import {
   shouldRenderField,
 } from './utils';
 import Iframe from 'react-iframe';
-import { IImage } from '../Photos';
-import Loader from '../Loader';
-import { useStatusMap } from '../../context/OnlineStatus/useStatusMap';
+import { IImage } from '@app/components/Photos';
+import Loader from '@app/components/Loader';
+import { useStatusMap } from '@app/context/OnlineStatus/useStatusMap';
 
 export interface IUserProfileCardProps {
   bio: string;

--- a/src/components/UserProfileCard/utils/index.ts
+++ b/src/components/UserProfileCard/utils/index.ts
@@ -1,4 +1,4 @@
-import { truncateString } from '../../../utils/truncateString';
+import { truncateString } from '@app/utils/truncateString';
 
 export const getLookingForTranslation = (lookingFor: string) => {
   switch (lookingFor) {

--- a/src/hooks/useGetAllImages.ts
+++ b/src/hooks/useGetAllImages.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { getAllImages } from '../api/uploads';
+import { getAllImages } from '@app/api/uploads';
 
 export const useGetAllImages = (id: string) => {
   const {

--- a/src/hooks/useGetAllUserChats.ts
+++ b/src/hooks/useGetAllUserChats.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { getAllUserChats } from '../api/chats';
+import { getAllUserChats } from '@app/api/chats';
 
 export const useGetAllUserChats = (userId: string, isQueryEnabled?: boolean) => {
   const {

--- a/src/hooks/useGetAllUsers.ts
+++ b/src/hooks/useGetAllUsers.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { getAllUsers } from '../api/users';
+import { getAllUsers } from '@app/api/users';
 
 export const useGetAllUsers = () => {
   const {

--- a/src/hooks/useGetUserById.ts
+++ b/src/hooks/useGetUserById.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { getUserById } from '../api/users';
+import { getUserById } from '@app/api/users';
 
 export const useGetUserById = (id: string) => {
   const {

--- a/src/pages/ChatPage/components/ChatGuard/index.tsx
+++ b/src/pages/ChatPage/components/ChatGuard/index.tsx
@@ -1,5 +1,5 @@
 import { useNavigate, useParams } from 'react-router';
-import { useGetCurrentChat } from '../../hooks';
+import { useGetCurrentChat } from '@app/pages/ChatPage/hooks';
 import { useLocalStorage } from '@uidotdev/usehooks';
 import { useEffect } from 'react';
 

--- a/src/pages/ChatPage/components/Message/index.tsx
+++ b/src/pages/ChatPage/components/Message/index.tsx
@@ -1,8 +1,8 @@
 import { useLocalStorage } from '@uidotdev/usehooks';
 import Avatar from 'react-avatar';
 import { useNavigate } from 'react-router';
-import RecordCreatedAt from '../../../../components/RecordCreatedAt';
-import { S3_CHAT_PHOTO_ENVIRONMENT, S3_URL } from '../../../../utils/consts';
+import RecordCreatedAt from '@app/components/RecordCreatedAt';
+import { S3_CHAT_PHOTO_ENVIRONMENT, S3_URL } from '@app/utils/consts';
 import { useEffect, useState } from 'react';
 
 type MessageType = 'text' | 'file' | 'gif';

--- a/src/pages/ChatPage/components/PaginatedMessages/index.tsx
+++ b/src/pages/ChatPage/components/PaginatedMessages/index.tsx
@@ -1,7 +1,7 @@
 import { useParams } from 'react-router';
-import Message, { IMessage } from '../Message';
-import { debounceScroll } from '../../../../utils/debounceScroll';
-import { useGetAllMessages } from '../../hooks';
+import Message, { IMessage } from '@app/pages/ChatPage/components/Message';
+import { debounceScroll } from '@app/utils/debounceScroll';
+import { useGetAllMessages } from '@app/pages/ChatPage/hooks';
 
 const PaginatedMessages = ({
   otherUserProfilePhoto,

--- a/src/pages/ChatPage/components/SendMessage/hooks/index.ts
+++ b/src/pages/ChatPage/components/SendMessage/hooks/index.ts
@@ -1,5 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
-import { uploadMessagePhotos } from '../../../../../api/uploads';
+import { uploadMessagePhotos } from '@app/api/uploads';
 
 export const useUploadMessageImage = () => {
   const {

--- a/src/pages/ChatPage/components/SendMessage/index.tsx
+++ b/src/pages/ChatPage/components/SendMessage/index.tsx
@@ -1,23 +1,23 @@
 import { useForm, Controller } from 'react-hook-form';
-import Button from '../../../../components/Button';
+import Button from '@app/components/Button';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
-import FieldError from '../../../../components/FieldError';
+import FieldError from '@app/components/FieldError';
 import { useLocalStorage } from '@uidotdev/usehooks';
-import { useGetAllUserChats } from '../../../../hooks/useGetAllUserChats';
-import { IChat } from '../../../NewChatPage/hooks';
-import { IUser } from '../../../../components/UserCard';
-import { useGetUserById } from '../../../../hooks/useGetUserById';
-import { useSocket } from '../../../../context/useSocket';
+import { useGetAllUserChats } from '@app/hooks/useGetAllUserChats';
+import { IChat } from '@app/pages/NewChatPage/hooks';
+import { IUser } from '@app/components/UserCard';
+import { useGetUserById } from '@app/hooks/useGetUserById';
+import { useSocket } from '@app/context/useSocket';
 import data from '@emoji-mart/data';
 import { SyntheticEvent, useState, useRef, useEffect } from 'react';
 import { init, SearchIndex } from 'emoji-mart';
-import EmojiPicker from '../../../../components/EmojiPicker';
+import EmojiPicker from '@app/components/EmojiPicker';
 import { debounce } from 'lodash';
-import Input from '../../../../components/Input';
+import Input from '@app/components/Input';
 import { BiPaperclip, BiSend, BiSolidFileGif } from 'react-icons/bi';
 import { useUploadMessageImage } from './hooks';
-import GiphySearch from '../../../../components/GiphySearch';
+import GiphySearch from '@app/components/GiphySearch';
 
 type Inputs = {
   content: string;

--- a/src/pages/ChatPage/hooks/index.ts
+++ b/src/pages/ChatPage/hooks/index.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useInfiniteQuery } from '@tanstack/react-query';
-import { getChatMessages } from '../../../api/chatMessages';
-import { deleteCurrentChat, getCurrentChat } from '../../../api/chats';
-import { toastConfig } from '../../../configs/toast.config';
+import { getChatMessages } from '@app/api/chatMessages';
+import { deleteCurrentChat, getCurrentChat } from '@app/api/chats';
+import { toastConfig } from '@app/configs/toast.config';
 import { toast } from 'react-toastify';
 import { useNavigate } from 'react-router';
 

--- a/src/pages/ChatPage/index.tsx
+++ b/src/pages/ChatPage/index.tsx
@@ -1,21 +1,21 @@
 import { useNavigate, useParams } from 'react-router';
-import AppLayout from '../../components/AppLayout';
-import Card from '../../components/Card';
+import AppLayout from '@app/components/AppLayout';
+import Card from '@app/components/Card';
 import SendMessage from './components/SendMessage';
 import { useEffect, useState } from 'react';
 import { useLocalStorage } from '@uidotdev/usehooks';
 import ChatGuard from './components/ChatGuard';
 import PaginatedMessages from './components/PaginatedMessages';
 import { useDeleteCurrentChat, useGetCurrentChat } from './hooks';
-import { useGetUserById } from '../../hooks/useGetUserById';
-import { useGetAllImages } from '../../hooks/useGetAllImages';
-import { getProfilePhoto, getProfilePhotoUrl } from '../../utils/getProfilePhoto';
-import Button from '../../components/Button';
-import { useSocket } from '../../context/useSocket';
-import ConfirmModal from '../../components/ConfirmModal';
-import { useStatusMap } from '../../context/OnlineStatus/useStatusMap';
+import { useGetUserById } from '@app/hooks/useGetUserById';
+import { useGetAllImages } from '@app/hooks/useGetAllImages';
+import { getProfilePhoto, getProfilePhotoUrl } from '@app/utils/getProfilePhoto';
+import Button from '@app/components/Button';
+import { useSocket } from '@app/context/useSocket';
+import ConfirmModal from '@app/components/ConfirmModal';
+import { useStatusMap } from '@app/context/OnlineStatus/useStatusMap';
 import { IMessage } from './components/Message';
-import ChatBubble from '../../components/ChatBubble';
+import ChatBubble from '@app/components/ChatBubble';
 
 interface IChatUser {
   userId: number;

--- a/src/pages/EditMyProfilePage/hooks/index.ts
+++ b/src/pages/EditMyProfilePage/hooks/index.ts
@@ -1,8 +1,8 @@
 import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from 'react-router';
-import { deleteUser, IUserUpdateProps, updateUser } from '../../../api/users';
+import { deleteUser, IUserUpdateProps, updateUser } from '@app/api/users';
 import { toast } from 'react-toastify';
-import { toastConfig } from '../../../configs/toast.config';
+import { toastConfig } from '@app/configs/toast.config';
 import { useAuth0 } from '@auth0/auth0-react';
 
 export const useUpdateUser = (userId: string) => {

--- a/src/pages/EditMyProfilePage/index.tsx
+++ b/src/pages/EditMyProfilePage/index.tsx
@@ -1,20 +1,20 @@
 import { BiSolidCamera, BiSolidFile } from 'react-icons/bi';
-import AppLayout from '../../components/AppLayout';
-import Card from '../../components/Card';
-import PhotoUploader from '../../components/PhotoUploader';
+import AppLayout from '@app/components/AppLayout';
+import Card from '@app/components/Card';
+import PhotoUploader from '@app/components/PhotoUploader';
 import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
-import Input from '../../components/Input';
+import Input from '@app/components/Input';
 import Select from 'react-select';
-import TextArea from '../../components/Textarea';
-import { useGetUserById } from '../../hooks/useGetUserById';
+import TextArea from '@app/components/Textarea';
+import { useGetUserById } from '@app/hooks/useGetUserById';
 import { useLocalStorage } from '@uidotdev/usehooks';
 import { useDeleteUser, useUpdateUser } from './hooks';
 import { Controller, SubmitHandler, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { useEffect, useState } from 'react';
-import Button from '../../components/Button';
-import ConfirmModal from '../../components/ConfirmModal';
+import Button from '@app/components/Button';
+import ConfirmModal from '@app/components/ConfirmModal';
 
 const lookingForOptions = [
   { value: 'friendship', label: 'Prijateljstvo' },

--- a/src/pages/Login/hooks/index.ts
+++ b/src/pages/Login/hooks/index.ts
@@ -1,8 +1,8 @@
 import { useMutation } from '@tanstack/react-query';
 import { useLocalStorage } from '@uidotdev/usehooks';
-import { register } from '../../../api/auth/register';
+import { register } from '@app/api/auth/register';
 import { toast } from 'react-toastify';
-import { toastConfig } from '../../../configs/toast.config';
+import { toastConfig } from '@app/configs/toast.config';
 import { useNavigate } from 'react-router';
 
 interface ISignupProps {

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -1,10 +1,10 @@
-import Button from '../../components/Button';
+import Button from '@app/components/Button';
 import { useAuth0 } from '@auth0/auth0-react';
-import Image1 from '../../assets/image1.png';
-import Image2 from '../../assets/image2.png';
-import Image3 from '../../assets/image3.png';
-import Image4 from '../../assets/image4.png';
-import Homepage from '../../assets/homepage.svg';
+import Image1 from '@app/assets/image1.png';
+import Image2 from '@app/assets/image2.png';
+import Image3 from '@app/assets/image3.png';
+import Image4 from '@app/assets/image4.png';
+import Homepage from '@app/assets/homepage.svg';
 
 const IS_STAGING = import.meta.env.STAGING;
 const URL = IS_STAGING ? 'https://dugastaging.netlify.app' : 'http://localhost:5173';

--- a/src/pages/MyProfilePage/index.tsx
+++ b/src/pages/MyProfilePage/index.tsx
@@ -1,16 +1,16 @@
 import { useLocalStorage } from '@uidotdev/usehooks';
-import AppLayout from '../../components/AppLayout';
-import Card from '../../components/Card';
-import Cta from '../../components/Cta';
-import Photos from '../../components/Photos';
+import AppLayout from '@app/components/AppLayout';
+import Card from '@app/components/Card';
+import Cta from '@app/components/Cta';
+import Photos from '@app/components/Photos';
 import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
 import { BiSolidCamera, BiSolidFile } from 'react-icons/bi';
 import { useNavigate } from 'react-router';
-import UserProfileCard from '../../components/UserProfileCard';
-import { useGetAllImages } from '../../hooks/useGetAllImages';
+import UserProfileCard from '@app/components/UserProfileCard';
+import { useGetAllImages } from '@app/hooks/useGetAllImages';
 import 'react-tabs/style/react-tabs.css';
-import { useGetUserById } from '../../hooks/useGetUserById';
-import Loader from '../../components/Loader';
+import { useGetUserById } from '@app/hooks/useGetUserById';
+import Loader from '@app/components/Loader';
 
 const MyProfilePage = () => {
   const navigate = useNavigate();

--- a/src/pages/NewChatPage/components/AllUserChats/index.tsx
+++ b/src/pages/NewChatPage/components/AllUserChats/index.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from 'react-router';
-import { IUser } from '../../../../components/UserCard';
-import UserChat from '../UserChat';
+import { IUser } from '@app/components/UserCard';
+import UserChat from '@app/pages/NewChatPage/components/UserChat';
 
 interface IChat {
   id: number;

--- a/src/pages/NewChatPage/components/UserChat/index.tsx
+++ b/src/pages/NewChatPage/components/UserChat/index.tsx
@@ -1,9 +1,9 @@
 import { BiChevronRight } from 'react-icons/bi';
-import { useGetAllImages } from '../../../../hooks/useGetAllImages';
-import Loader from '../../../../components/Loader';
-import { getProfilePhotoUrl } from '../../../../utils/getProfilePhoto';
+import { useGetAllImages } from '@app/hooks/useGetAllImages';
+import Loader from '@app/components/Loader';
+import { getProfilePhotoUrl } from '@app/utils/getProfilePhoto';
 import Avatar from 'react-avatar';
-import { useGetIsMessageRead, useMarkMessagesAsRead } from '../../hooks';
+import { useGetIsMessageRead, useMarkMessagesAsRead } from '@app/pages/NewChatPage/hooks';
 import { useLocalStorage } from '@uidotdev/usehooks';
 
 interface IMessage {

--- a/src/pages/NewChatPage/hooks/index.ts
+++ b/src/pages/NewChatPage/hooks/index.ts
@@ -1,9 +1,9 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
-import { createChat } from '../../../api/chats';
+import { createChat } from '@app/api/chats';
 import { toast } from 'react-toastify';
-import { toastConfig } from '../../../configs/toast.config';
+import { toastConfig } from '@app/configs/toast.config';
 import { useNavigate } from 'react-router';
-import { isMessageRead, markMessagesAsRead } from '../../../api/chatMessages';
+import { isMessageRead, markMessagesAsRead } from '@app/api/chatMessages';
 
 interface CreateChatInput {
   userId: number;

--- a/src/pages/NewChatPage/index.tsx
+++ b/src/pages/NewChatPage/index.tsx
@@ -1,12 +1,12 @@
 import { useState } from 'react';
-import AppLayout from '../../components/AppLayout';
-import Input from '../../components/Input';
-import { useGetAllUsers } from '../../hooks/useGetAllUsers';
-import UserCard, { IUser } from '../../components/UserCard';
+import AppLayout from '@app/components/AppLayout';
+import Input from '@app/components/Input';
+import { useGetAllUsers } from '@app/hooks/useGetAllUsers';
+import UserCard, { IUser } from '@app/components/UserCard';
 import { useCreateNewChat } from './hooks';
 import { useLocalStorage } from '@uidotdev/usehooks';
-import Loader from '../../components/Loader';
-import { useGetAllUserChats } from '../../hooks/useGetAllUserChats';
+import Loader from '@app/components/Loader';
+import { useGetAllUserChats } from '@app/hooks/useGetAllUserChats';
 import AllUserChats from './components/AllUserChats';
 
 const NewChatPage = () => {

--- a/src/pages/NotFoundPage/index.tsx
+++ b/src/pages/NotFoundPage/index.tsx
@@ -1,5 +1,5 @@
-import AppLayout from '../../components/AppLayout';
-import NotFoundPageSvg from '../../assets/not_found_page.svg';
+import AppLayout from '@app/components/AppLayout';
+import NotFoundPageSvg from '@app/assets/not_found_page.svg';
 
 const NotFoundPage = () => {
   return (

--- a/src/pages/OtherUserPage/index.tsx
+++ b/src/pages/OtherUserPage/index.tsx
@@ -1,15 +1,15 @@
 import { useParams } from 'react-router';
-import AppLayout from '../../components/AppLayout';
+import AppLayout from '@app/components/AppLayout';
 import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
 import { BiSolidCamera, BiSolidFile } from 'react-icons/bi';
-import UserProfileCard from '../../components/UserProfileCard';
-import { useGetAllImages } from '../../hooks/useGetAllImages';
-import Cta from '../../components/Cta';
-import Card from '../../components/Card';
-import Photos from '../../components/Photos';
-import { useGetUserById } from '../../hooks/useGetUserById';
-import Loader from '../../components/Loader';
-import SendMessageButton from '../../components/SendMessageButton';
+import UserProfileCard from '@app/components/UserProfileCard';
+import { useGetAllImages } from '@app/hooks/useGetAllImages';
+import Cta from '@app/components/Cta';
+import Card from '@app/components/Card';
+import Photos from '@app/components/Photos';
+import { useGetUserById } from '@app/hooks/useGetUserById';
+import Loader from '@app/components/Loader';
+import SendMessageButton from '@app/components/SendMessageButton';
 
 const OtherUserPage = () => {
   const { userId } = useParams();

--- a/src/pages/PhotoPage/hooks/index.ts
+++ b/src/pages/PhotoPage/hooks/index.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { getSingleImage } from '../../../api/uploads';
+import { getSingleImage } from '@app/api/uploads';
 
 export const useGetSingleImage = (id: string) => {
   const {

--- a/src/pages/PhotoPage/index.tsx
+++ b/src/pages/PhotoPage/index.tsx
@@ -1,12 +1,12 @@
 import { useParams } from 'react-router';
-import AppLayout from '../../components/AppLayout';
+import AppLayout from '@app/components/AppLayout';
 import { useGetSingleImage } from './hooks';
-import { getPhotoUrl } from '../../utils/getPhotoUrl';
-import Card from '../../components/Card';
-import PhotoComments from '../../components/PhotoComments';
-import PhotoLikes from '../../components/PhotoLikes';
-import Loader from '../../components/Loader';
-import notFound from '../../assets/not_found.svg';
+import { getPhotoUrl } from '@app/utils/getPhotoUrl';
+import Card from '@app/components/Card';
+import PhotoComments from '@app/components/PhotoComments';
+import PhotoLikes from '@app/components/PhotoLikes';
+import Loader from '@app/components/Loader';
+import notFound from '@app/assets/not_found.svg';
 
 const PhotoPage = () => {
   const { photoId } = useParams();

--- a/src/pages/VerifyEmailPage/index.tsx
+++ b/src/pages/VerifyEmailPage/index.tsx
@@ -1,9 +1,9 @@
 import { useAuth0 } from '@auth0/auth0-react';
 import { Navigate, useNavigate } from 'react-router';
-import AuthLayout from '../../components/AuthLayout';
-import Button from '../../components/Button';
+import AuthLayout from '@app/components/AuthLayout';
+import Button from '@app/components/Button';
 import { toast } from 'react-toastify';
-import { toastConfig } from '../../configs/toast.config';
+import { toastConfig } from '@app/configs/toast.config';
 
 const VerifyEmailPage = () => {
   const navigate = useNavigate();

--- a/src/routes/guards/AuthGuard.tsx
+++ b/src/routes/guards/AuthGuard.tsx
@@ -2,7 +2,7 @@ import { Navigate } from 'react-router-dom';
 import { useAuth0 } from '@auth0/auth0-react';
 import { useEffect } from 'react';
 import { useCookies } from 'react-cookie';
-import Loader from '../../components/Loader';
+import Loader from '@app/components/Loader';
 
 interface IAuthGuardProps {
   children: React.ReactNode;

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,15 +1,15 @@
 import { Route, Routes } from 'react-router';
-import App from '../App';
-import LoginPage from '../pages/Login';
-import MyProfilePage from '../pages/MyProfilePage';
-import EditMyProfilePage from '../pages/EditMyProfilePage';
-import OtherUserPage from '../pages/OtherUserPage';
-import PhotoPage from '../pages/PhotoPage';
-import NewChatPage from '../pages/NewChatPage';
-import ChatPage from '../pages/ChatPage';
-import NotFoundPage from '../pages/NotFoundPage';
+import App from '@app/App';
+import LoginPage from '@app/pages/Login';
+import MyProfilePage from '@app/pages/MyProfilePage';
+import EditMyProfilePage from '@app/pages/EditMyProfilePage';
+import OtherUserPage from '@app/pages/OtherUserPage';
+import PhotoPage from '@app/pages/PhotoPage';
+import NewChatPage from '@app/pages/NewChatPage';
+import ChatPage from '@app/pages/ChatPage';
+import NotFoundPage from '@app/pages/NotFoundPage';
 import { AuthGuard } from './guards/AuthGuard';
-import VerifyEmailPage from '../pages/VerifyEmailPage';
+import VerifyEmailPage from '@app/pages/VerifyEmailPage';
 
 const DugaRoutes = () => {
   return (

--- a/src/utils/getImageUrl.ts
+++ b/src/utils/getImageUrl.ts
@@ -1,4 +1,4 @@
-import { IImage } from '../components/Photos';
+import { IImage } from '@app/components/Photos';
 import { S3_URL } from './consts';
 
 export const getImageUrl = (image: IImage) => {

--- a/src/utils/getPhotoUrl.ts
+++ b/src/utils/getPhotoUrl.ts
@@ -1,4 +1,4 @@
-import { IImage } from '../components/Photos';
+import { IImage } from '@app/components/Photos';
 import { S3_URL } from './consts';
 
 export const getPhotoUrl = (photo: IImage | undefined) => {

--- a/src/utils/getProfilePhoto.ts
+++ b/src/utils/getProfilePhoto.ts
@@ -1,4 +1,4 @@
-import { IImage } from '../components/Photos';
+import { IImage } from '@app/components/Photos';
 import { S3_URL } from './consts';
 export const getProfilePhotoUrl = (profilePhoto: IImage | undefined) => {
   if (profilePhoto) {

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -20,7 +20,12 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+
+    "baseUrl": ".",
+    "paths": {
+      "@app/*": ["src/*"]
+    }
   },
   "include": ["src"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
+import path from 'path';
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -15,6 +16,11 @@ export default defineConfig({
       ],
     }),
   ],
+  resolve:{
+    alias: {
+      '@app': path.resolve(__dirname, 'src'),
+    }
+  },
   define: {
     'import.meta.env.STAGING': JSON.stringify(Boolean(process.env.STAGING)),
   },


### PR DESCRIPTION
- global refactor all relatives paths `(../../../)` to absolute imports using `@app/` alias
- used _find/replace_ with Regex command in order to perform an automatic and secure migration
- maintained consistency and readability across all modules
