### PR TITLE
Images now have same aspect ratio and input fileds are aligned

### DIFF
--- a/src/components/PhotoUploader/index.tsx
+++ b/src/components/PhotoUploader/index.tsx
@@ -283,7 +283,13 @@ const PhotoUploader = () => {
               newImages.map((image) => {
                 return (
                   <div key={image.name} className="mb-4 max-w-[400px]">
-                    <img src={image.url} alt={image.name} />
+                    <div className="relative w-full aspect-[1/1] overflow-hidden rounded-md">
+                      <img
+                        src={image.url}
+                        alt={image.name}
+                        className="absolute top-0 left-0 w-full h-full object-cover"
+                      />
+                    </div>
                     <PhotoActionButtons
                       onInputChange={(e: SyntheticEvent) => onDescriptionChange(e, image)}
                       onDelete={() => onDeleteFromState(image)}


### PR DESCRIPTION
![Screenshot_3](https://github.com/user-attachments/assets/c01699a6-8d68-4021-a6b2-c73f8744b45e)
Photos that are ready for upload are now rendered as 1:1 aspect ratio (no matter to their actual dimenstions).
So all inputs and buttons below photos are aligned.