### PR TITLE
feat(mark-all-as-read): mark all notifications as read

### DIFF
--- a/src/api/notifications/index.ts
+++ b/src/api/notifications/index.ts
@@ -9,3 +9,10 @@ export const markAsReadNotification = async (notificationId: string) => {
   const client = apiClient();
   return client.put(`/notifications/${notificationId}/read`);
 };
+
+export const markAllAsReadNotifications = async (userId: string) => {
+  const client = apiClient();
+  return client.put(`/notifications/mark-all-read`, {
+    userId,
+  });
+};

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -8,7 +8,8 @@ export type ButtonType =
   | 'black'
   | 'blue'
   | 'danger'
-  | 'blue-dark';
+  | 'blue-dark'
+  | 'transparent';
 
 interface IButtonProps {
   children: React.ReactNode;
@@ -38,6 +39,8 @@ const getBackgroundColor = (type: IButtonProps['type']) => {
       return 'py-2 px-4 bg-red text-white';
     case 'blue-dark':
       return 'py-2 px-4 bg-blue-dark text-white';
+    case 'transparent':
+      return 'py-2 px-4 bg-transparent text-black hover:bg-gray-200 underline hover:text-black';
     default:
       return 'bg-blue';
   }

--- a/src/components/Navigation/components/Notification/index.tsx
+++ b/src/components/Navigation/components/Notification/index.tsx
@@ -11,7 +11,6 @@ interface INotificationProps {
 const Notification = ({ n, isMobile, setNotifications }: INotificationProps) => {
   const { mutateMarkAsRead } = useMarkAsReadNotification();
   const navigate = useNavigate();
-  console.log('Notification component rendered', n);
 
   return (
     <div

--- a/src/components/Navigation/components/Notifications/index.tsx
+++ b/src/components/Navigation/components/Notifications/index.tsx
@@ -101,7 +101,7 @@ const NotificationDropdown = ({
         >
           <Button
             type="transparent"
-            className="w-full"
+            className="w-full text-left"
             onClick={() => {
               mutateMarkAllAsRead();
               setNotifications((prev) => prev.map((n) => ({ ...n, isRead: true })));

--- a/src/components/Navigation/components/Notifications/index.tsx
+++ b/src/components/Navigation/components/Notifications/index.tsx
@@ -1,7 +1,11 @@
 import { useEffect, useRef, useState } from 'react';
-import { useGetAllNotifcations } from '@app/components/Navigation/hooks';
+import {
+  useGetAllNotifcations,
+  useMarkAllAsReadNotifications,
+} from '@app/components/Navigation/hooks';
 import { useSocket } from '@app/context/useSocket';
 import Notification from './../Notification';
+import Button from '@app/components/Button';
 
 export type INotification = {
   id: number;
@@ -24,9 +28,9 @@ const NotificationDropdown = ({
   const socket = useSocket();
   const dropdownRef = useRef<HTMLDivElement>(null);
   const { allNotifications } = useGetAllNotifcations(String(userId) || '');
-
   const [notifications, setNotifications] = useState<INotification[]>([]);
   const [open, setOpen] = useState(false);
+  const { mutateMarkAllAsRead } = useMarkAllAsReadNotifications();
 
   useEffect(() => {
     if (allNotifications) {
@@ -95,6 +99,16 @@ const NotificationDropdown = ({
         <div
           className={`absolute left-0 right-0 mt-1 w-52 ${isMobile ? 'bg-black' : 'bg-white'} shadow-xl rounded-lg z-10 max-h-96 overflow-y-auto`}
         >
+          <Button
+            type="transparent"
+            className="w-full"
+            onClick={() => {
+              mutateMarkAllAsRead();
+              setNotifications((prev) => prev.map((n) => ({ ...n, isRead: true })));
+            }}
+          >
+            Označi sve kao pročitano
+          </Button>
           {notifications.length === 0 ? (
             <div className="p-4 text-sm text-black">Nema obavijesti</div>
           ) : (

--- a/src/components/Navigation/hooks/index.ts
+++ b/src/components/Navigation/hooks/index.ts
@@ -1,5 +1,9 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { getAllNotifications, markAsReadNotification } from '@app/api/notifications';
+import {
+  getAllNotifications,
+  markAllAsReadNotifications,
+  markAsReadNotification,
+} from '@app/api/notifications';
 import { useLocalStorage } from '@uidotdev/usehooks';
 
 export const useGetAllNotifcations = (userId: string) => {
@@ -42,5 +46,30 @@ export const useMarkAsReadNotification = () => {
     isMarkingAsRead,
     isMarkAsReadError,
     isMarkAsReadSuccess,
+  };
+};
+
+export const useMarkAllAsReadNotifications = () => {
+  const [userId] = useLocalStorage('userId');
+  const queryClient = useQueryClient();
+  const {
+    mutate: mutateMarkAllAsRead,
+    isPending: isMarkingAllAsRead,
+    isError: isMarkAllAsReadError,
+    isSuccess: isMarkAllAsReadSuccess,
+  } = useMutation({
+    mutationFn: () => markAllAsReadNotifications(String(userId)),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['notifications', userId],
+      });
+    },
+  });
+
+  return {
+    mutateMarkAllAsRead,
+    isMarkingAllAsRead,
+    isMarkAllAsReadError,
+    isMarkAllAsReadSuccess,
   };
 };


### PR DESCRIPTION
- add button to mark all notifications as read

![Screenshot 2025-06-23 at 08 37 09](https://github.com/user-attachments/assets/ad48e233-00f8-49af-aad2-f533c789fe18)

- do not merge until https://github.com/tonkec/duga_backend/pull/17 is merged
- closes https://trello.com/c/05pMHb5e/122-mark-all-notifications-as-read