### PR TITLE
bug(content-formatter): add content formatter to more components

### DIFF
--- a/src/components/LatestComments/index.tsx
+++ b/src/components/LatestComments/index.tsx
@@ -8,6 +8,7 @@ import DOMPurify from 'dompurify';
 import { useGetImageBlob } from '../LatestUploads/hooks';
 import UserAvatar from '../UserAvatar';
 import Image from '../Image';
+import ContentFormatter from '../ContentFormatter';
 
 interface IComment {
   id: number;
@@ -52,7 +53,11 @@ export const LatestComment = ({ comment, onClick }: { comment: IComment; onClick
         }
       }
 
-      return <span key={index}>{part}</span>;
+      return (
+        <span key={index}>
+          <ContentFormatter text={part} />
+        </span>
+      );
     });
   };
 

--- a/src/components/LatestMessages/index.tsx
+++ b/src/components/LatestMessages/index.tsx
@@ -9,6 +9,7 @@ import BlobImage from '../PhotoUploader/components/BlobImage';
 import UserAvatar from '../UserAvatar';
 import GiphyMessage from '@app/pages/ChatPage/components/GiphyMessage';
 import { IMessage } from '@app/pages/ChatPage/components/Message';
+import ContentFormatter from '../ContentFormatter';
 
 interface IMessageWrapper {
   message: IMessage;
@@ -63,7 +64,11 @@ const LatestMessage = ({ message, onClick }: { message: IMessage; onClick: () =>
       return <BlobImage imageUrl={message.securePhotoUrl} name="komentar" className="w-32 h-32" />;
     }
 
-    return <span className="text-black">{message.message}</span>;
+    return (
+      <span className="text-black">
+        <ContentFormatter text={message.message} />
+      </span>
+    );
   };
 
   return (

--- a/src/pages/NewChatPage/components/LastMessage/index.tsx
+++ b/src/pages/NewChatPage/components/LastMessage/index.tsx
@@ -1,3 +1,4 @@
+import ContentFormatter from '@app/components/ContentFormatter';
 import BlobImage from '@app/components/PhotoUploader/components/BlobImage';
 import GiphyMessage from '@app/pages/ChatPage/components/GiphyMessage';
 import { IMessage } from '@app/pages/ChatPage/components/Message';
@@ -8,7 +9,11 @@ interface ILastMessageProps {
 
 const LastMessage = ({ message }: ILastMessageProps) => {
   if (message.message) {
-    return <p className="text-gray-500">{message.message}</p>;
+    return (
+      <p className="text-gray-500">
+        <ContentFormatter text={message.message} />
+      </p>
+    );
   }
 
   if (message.type === 'gif') {


### PR DESCRIPTION
- https://trello.com/c/JSsMfjf0/188-read-media-content-in-leftover-components

<img width="689" height="620" alt="Screenshot 2025-08-15 at 08 07 16" src="https://github.com/user-attachments/assets/ed204510-d464-4c82-ae6b-97bdc1bb152d" />

